### PR TITLE
Configured code formatting plugin with the set of rules

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,9 +14,10 @@
 
 * It would be really nice if your followed the basic code format used prevelently.
 
-#### **Please don't reformat existing code**
+#### **Code format**
 
-* Just because you don't like a given code style doesn't mean you have the authority to change it. Cosmeic changes add zero to little value.
+* Import the code format settings from `resources/eclipse-java-formatter.xml` file.
+* Before committing, run `mvn spotless:check`. Note the build will fail if there are any files that are not formatted accordingly. 
 
 #### **New features and enhancements**
 

--- a/pom.xml
+++ b/pom.xml
@@ -90,6 +90,35 @@
           </execution>
         </executions>
       </plugin>
+      <plugin>
+        <groupId>com.diffplug.spotless</groupId>
+        <artifactId>spotless-maven-plugin</artifactId>
+        <version>1.23.0</version>
+        <configuration>
+          <java>
+            <includes>
+              <!-- Include all property files in "resource" folders under "src" -->
+              <include>src/main/java/io/vlingo/**/*.java</include>
+              <include>src/test/java/io/vlingo/**/*.java</include>
+            </includes>
+            <eclipse>
+              <file>${basedir}/resources/eclipse-java-formatter.xml</file>
+            </eclipse>
+            <trimTrailingWhitespace/>
+            <removeUnusedImports/>
+          </java>
+        </configuration>
+        <executions>
+          <execution>
+            <!-- Runs in compile phase to fail fast in case of formatting issues.-->
+            <id>spotless-check</id>
+            <phase>compile</phase>
+            <goals>
+              <goal>check</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
   <repositories>

--- a/resources/eclipse-java-formatter.xml
+++ b/resources/eclipse-java-formatter.xml
@@ -1,0 +1,318 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<profiles version="14">
+    <profile kind="CodeFormatterProfile" name="Eclipse [vlingo-platform]" version="14">
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_ellipsis" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_enum_declarations" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_new_line_in_empty_annotation_declaration" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_allocation_expression" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_at_in_annotation_type_declaration" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.parentheses_positions_in_for_statment" value="common_lines"/>
+        <setting id="org.eclipse.jdt.core.formatter.comment.new_lines_at_block_boundaries" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_constructor_declaration_parameters" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.comment.insert_new_line_for_parameter" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_annotation_on_package" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.parentheses_positions_in_method_invocation" value="common_lines"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_between_empty_parens_in_enum_constant" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.blank_lines_after_imports" value="1"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_while" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.comment.insert_new_line_before_root_tags" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_between_empty_parens_in_annotation_type_member_declaration" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_method_declaration_throws" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.parentheses_positions_in_switch_statement" value="common_lines"/>
+        <setting id="org.eclipse.jdt.core.formatter.comment.format_javadoc_comments" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.indentation.size" value="2"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_postfix_operator" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.parentheses_positions_in_enum_constant_declaration" value="common_lines"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_for_increments" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_type_arguments" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_for_inits" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_new_line_in_empty_anonymous_type_declaration" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_semicolon_in_for" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.align_with_spaces" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.disabling_tag" value="@formatter:off"/>
+        <setting id="org.eclipse.jdt.core.formatter.continuation_indentation" value="4"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_enum_constants" value="0"/>
+        <setting id="org.eclipse.jdt.core.formatter.blank_lines_before_imports" value="1"/>
+        <setting id="org.eclipse.jdt.core.formatter.blank_lines_after_package" value="1"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_binary_operator" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_multiple_local_declarations" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.parentheses_positions_in_if_while_statement" value="common_lines"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_enum_constant" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_angle_bracket_in_parameterized_type_reference" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.comment.indent_root_tags" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.wrap_before_or_operator_multicatch" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.enabling_tag" value="@formatter:on"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_closing_brace_in_block" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.comment.count_line_length_from_starting_position" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_parenthesized_expression_in_return" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_throws_clause_in_method_declaration" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_annotation_on_parameter" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.keep_then_statement_on_same_line" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_annotation_on_field" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_explicitconstructorcall_arguments" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_new_line_in_empty_block" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_prefix_operator" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.blank_lines_between_type_declarations" value="1"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_brace_in_array_initializer" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_for" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_catch" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_angle_bracket_in_type_arguments" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_annotation_on_method" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_switch" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_parameterized_type_references" value="0"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_anonymous_type_declaration" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_parenthesized_expression" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_annotation_on_enum_constant" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.never_indent_line_comments_on_first_column" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_and_in_type_parameter" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_for_inits" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.indent_statements_compare_to_block" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.brace_position_for_anonymous_type_declaration" value="end_of_line"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_question_in_wildcard" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_annotation" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_method_invocation_arguments" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_switch" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.comment.align_tags_descriptions_grouped" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.comment.line_length" value="80"/>
+        <setting id="org.eclipse.jdt.core.formatter.use_on_off_tags" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_between_empty_brackets_in_array_allocation_expression" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_enum_constant" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_between_empty_parens_in_method_invocation" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_assignment_operator" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_type_declaration" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_for" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.comment.preserve_white_space_between_code_and_line_comments" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_annotation_on_local_variable" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.brace_position_for_method_declaration" value="end_of_line"/>
+        <setting id="org.eclipse.jdt.core.formatter.align_variable_declarations_on_columns" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_method_invocation" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_union_type_in_multicatch" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_colon_in_for" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.number_of_blank_lines_at_beginning_of_method_body" value="0"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_closing_angle_bracket_in_type_arguments" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.keep_else_statement_on_same_line" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_binary_expression" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.parentheses_positions_in_catch_clause" value="common_lines"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_parameterized_type_reference" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_array_initializer" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_multiple_field_declarations" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_annotation" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_explicit_constructor_call" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.indent_body_declarations_compare_to_annotation_declaration_header" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_superinterfaces" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_colon_in_default" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_question_in_conditional" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.brace_position_for_block" value="end_of_line"/>
+        <setting id="org.eclipse.jdt.core.formatter.brace_position_for_constructor_declaration" value="end_of_line"/>
+        <setting id="org.eclipse.jdt.core.formatter.brace_position_for_lambda_body" value="end_of_line"/>
+        <setting id="org.eclipse.jdt.core.formatter.compact_else_if" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_type_parameters" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_catch" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_method_invocation" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.put_empty_statement_on_new_line" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_parameters_in_constructor_declaration" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_type_parameters" value="0"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_method_invocation_arguments" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_method_invocation" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_throws_clause_in_constructor_declaration" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_compact_loops" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.comment.clear_blank_lines_in_block_comment" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_new_line_before_catch_in_try_statement" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_try" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.keep_simple_for_body_on_same_line" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_new_line_at_end_of_file_if_missing" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.comment.clear_blank_lines_in_javadoc_comment" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_array_initializer" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_binary_operator" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_unary_operator" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_expressions_in_array_initializer" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.format_line_comment_starting_on_first_column" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.number_of_empty_lines_to_preserve" value="1"/>
+        <setting id="org.eclipse.jdt.core.formatter.parentheses_positions_in_annotation" value="common_lines"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_colon_in_case" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_ellipsis" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_semicolon_in_try_resources" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_colon_in_assert" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_if" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_type_arguments" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_and_in_type_parameter" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_new_line_in_empty_type_declaration" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_parenthesized_expression" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.comment.format_line_comments" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_colon_in_labeled_statement" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.align_type_members_on_columns" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_assignment" value="0"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_module_statements" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_new_line_in_empty_method_body" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.indent_body_declarations_compare_to_type_header" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_between_empty_parens_in_method_declaration" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.comment.align_tags_names_descriptions" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_enum_constant" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_superinterfaces_in_type_declaration" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.blank_lines_before_first_class_body_declaration" value="0"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_conditional_expression" value="80"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_new_line_before_closing_brace_in_array_initializer" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_constructor_declaration_parameters" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.format_guardian_clause_on_one_line" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_if" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.align_assignment_statements_on_columns" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_annotation_on_type" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_block" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.brace_position_for_enum_declaration" value="end_of_line"/>
+        <setting id="org.eclipse.jdt.core.formatter.brace_position_for_block_in_case" value="end_of_line"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_constructor_declaration" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.comment.format_header" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_allocation_expression" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_method_invocation" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_while" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_switch" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_method_declaration" value="0"/>
+        <setting id="org.eclipse.jdt.core.formatter.join_wrapped_lines" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_between_empty_parens_in_constructor_declaration" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.wrap_before_conditional_operator" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.indent_switchstatements_compare_to_cases" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_bracket_in_array_allocation_expression" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_synchronized" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.align_fields_grouping_blank_lines" value="2147483647"/>
+        <setting id="org.eclipse.jdt.core.formatter.comment.new_lines_at_javadoc_boundaries" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.brace_position_for_annotation_type_declaration" value="end_of_line"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_colon_in_for" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_resources_in_try" value="80"/>
+        <setting id="org.eclipse.jdt.core.formatter.use_tabs_only_for_leading_indentations" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.parentheses_positions_in_try_clause" value="common_lines"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_selector_in_method_invocation" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.never_indent_block_comments_on_first_column" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_synchronized" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_constructor_declaration_throws" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.tabulation.size" value="2"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_new_line_in_empty_enum_constant" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_allocation_expression" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_bracket_in_array_reference" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_colon_in_conditional" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.comment.format_source_code" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_array_initializer" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_try" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_semicolon_in_try_resources" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.blank_lines_before_field" value="0"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_at_in_annotation" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.continuation_indentation_for_array_initializer" value="2"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_question_in_wildcard" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.blank_lines_before_method" value="1"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_superclass_in_type_declaration" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_superinterfaces_in_enum_declaration" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_parenthesized_expression_in_throw" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.wrap_before_assignment_operator" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_colon_in_labeled_statement" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.brace_position_for_switch" value="end_of_line"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_superinterfaces" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_method_declaration_parameters" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_type_annotation" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_brace_in_array_initializer" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_parenthesized_expression" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.comment.format_html" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_at_in_annotation_type_declaration" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_closing_angle_bracket_in_type_parameters" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.parentheses_positions_in_method_delcaration" value="common_lines"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_compact_if" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.indent_empty_lines" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_type_arguments" value="0"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_parameterized_type_reference" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_unary_operator" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_enum_constant" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_annotation" value="0"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_enum_declarations" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.keep_empty_array_initializer_on_one_line" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.indent_switchstatements_compare_to_switch" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_new_line_before_else_in_if_statement" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_assignment_operator" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_constructor_declaration" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.blank_lines_before_new_chunk" value="1"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_label" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.indent_body_declarations_compare_to_enum_declaration_header" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_bracket_in_array_allocation_expression" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_constructor_declaration" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_colon_in_conditional" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_angle_bracket_in_parameterized_type_reference" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_method_declaration_parameters" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_angle_bracket_in_type_arguments" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_cast" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_colon_in_assert" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.blank_lines_before_member_type" value="1"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_new_line_before_while_in_do_statement" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_bracket_in_array_type_reference" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_angle_bracket_in_parameterized_type_reference" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_qualified_allocation_expression" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_opening_brace_in_array_initializer" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_new_line_in_empty_enum_declaration" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.indent_breaks_compare_to_cases" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_method_declaration" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_if" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_semicolon" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_postfix_operator" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_try" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_angle_bracket_in_type_arguments" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_cast" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.comment.format_block_comments" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_lambda_arrow" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_method_declaration" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.keep_imple_if_on_one_line" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_enum_declaration" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_parameters_in_method_declaration" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_between_brackets_in_array_type_reference" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_angle_bracket_in_type_parameters" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_semicolon_in_for" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_method_declaration_throws" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_bracket_in_array_allocation_expression" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.indent_statements_compare_to_body" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_multiple_fields" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_enum_constant_arguments" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.keep_simple_while_body_on_same_line" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_prefix_operator" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.brace_position_for_array_initializer" value="end_of_line"/>
+        <setting id="org.eclipse.jdt.core.formatter.wrap_before_binary_operator" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_method_declaration" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_type_parameters" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_catch" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_bracket_in_array_reference" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_annotation" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_enum_constant_arguments" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.parentheses_positions_in_lambda_declaration" value="common_lines"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_between_empty_braces_in_array_initializer" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_colon_in_case" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_multiple_local_declarations" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.keep_simple_do_while_body_on_same_line" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_annotation_type_declaration" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_bracket_in_array_reference" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_method_declaration" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.wrap_outer_expressions_when_nested" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_closing_paren_in_cast" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.brace_position_for_enum_constant" value="end_of_line"/>
+        <setting id="org.eclipse.jdt.core.formatter.brace_position_for_type_declaration" value="end_of_line"/>
+        <setting id="org.eclipse.jdt.core.formatter.blank_lines_before_package" value="0"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_for" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_synchronized" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_for_increments" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_annotation_type_member_declaration" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_expressions_in_for_loop_header" value="0"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_while" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_enum_constant" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_explicitconstructorcall_arguments" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_annotation" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_angle_bracket_in_type_parameters" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.indent_body_declarations_compare_to_enum_constant_header" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_lambda_arrow" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_constructor_declaration" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_constructor_declaration_throws" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.join_lines_in_comments" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_angle_bracket_in_type_parameters" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_question_in_conditional" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.comment.indent_parameter_description" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_new_line_before_finally_in_try_statement" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.tabulation.char" value="space"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_multiple_field_declarations" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.blank_lines_between_import_groups" value="1"/>
+        <setting id="org.eclipse.jdt.core.formatter.lineSplit" value="120"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_annotation" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_switch" value="insert"/>
+    </profile>
+</profiles>

--- a/src/main/java/io/vlingo/directory/client/DirectoryClient.java
+++ b/src/main/java/io/vlingo/directory/client/DirectoryClient.java
@@ -18,32 +18,24 @@ public interface DirectoryClient extends Stoppable {
   public static final int DefaultProcessingInterval = 1000;
   public static final int DefaultProcessingTimeout = 10;
 
-  public static DirectoryClient instance(
-          final Stage stage,
-          final ServiceDiscoveryInterest interest,
+  public static DirectoryClient instance(final Stage stage, final ServiceDiscoveryInterest interest,
           final Group directoryPublisherGroup) {
-    
-    return instance(stage, interest, directoryPublisherGroup,
-            DefaultMaxMessageSize, DefaultProcessingInterval, DefaultProcessingTimeout);
+
+    return instance(stage, interest, directoryPublisherGroup, DefaultMaxMessageSize, DefaultProcessingInterval,
+            DefaultProcessingTimeout);
   }
 
-  public static DirectoryClient instance(
-          final Stage stage,
-          final ServiceDiscoveryInterest interest,
-          final Group directoryPublisherGroup,
-          final int maxMessageSize,
-          final long processingInterval,
+  public static DirectoryClient instance(final Stage stage, final ServiceDiscoveryInterest interest,
+          final Group directoryPublisherGroup, final int maxMessageSize, final long processingInterval,
           final int processingTimeout) {
-    
-    final Definition definition =
-            Definition.has(
-                    DirectoryClientActor.class,
-                    Definition.parameters(interest, directoryPublisherGroup, maxMessageSize, processingInterval, processingTimeout),
-                    ClientName);
-    
+
+    final Definition definition = Definition.has(DirectoryClientActor.class, Definition.parameters(interest,
+            directoryPublisherGroup, maxMessageSize, processingInterval, processingTimeout), ClientName);
+
     return stage.actorFor(DirectoryClient.class, definition);
   }
-  
+
   void register(final ServiceRegistrationInfo info);
+
   void unregister(final String serviceName);
 }

--- a/src/main/java/io/vlingo/directory/client/DirectoryClient__Proxy.java
+++ b/src/main/java/io/vlingo/directory/client/DirectoryClient__Proxy.java
@@ -30,8 +30,11 @@ public class DirectoryClient__Proxy implements DirectoryClient {
   public void conclude() {
     if (!actor.isStopped()) {
       final Consumer<Stoppable> consumer = (actor) -> actor.conclude();
-      if (mailbox.isPreallocated()) { mailbox.send(actor, Stoppable.class, consumer, null, representationConclude0); }
-      else { mailbox.send(new LocalMessage<Stoppable>(actor, Stoppable.class, consumer, representationConclude0)); }
+      if (mailbox.isPreallocated()) {
+        mailbox.send(actor, Stoppable.class, consumer, null, representationConclude0);
+      } else {
+        mailbox.send(new LocalMessage<Stoppable>(actor, Stoppable.class, consumer, representationConclude0));
+      }
     } else {
       actor.deadLetters().failedDelivery(new DeadLetter(actor, representationConclude0));
     }
@@ -56,7 +59,8 @@ public class DirectoryClient__Proxy implements DirectoryClient {
   public void register(final ServiceRegistrationInfo info) {
     if (!actor.isStopped()) {
       final Consumer<DirectoryClient> consumer = (actor) -> actor.register(info);
-      mailbox.send(new LocalMessage<DirectoryClient>(actor, DirectoryClient.class, consumer, "register(ServiceRegistrationInfo)"));
+      mailbox.send(new LocalMessage<DirectoryClient>(actor, DirectoryClient.class, consumer,
+              "register(ServiceRegistrationInfo)"));
     } else {
       actor.deadLetters().failedDelivery(new DeadLetter(actor, "register(ServiceRegistrationInfo)"));
     }

--- a/src/main/java/io/vlingo/directory/client/ServiceDiscoveryInterest.java
+++ b/src/main/java/io/vlingo/directory/client/ServiceDiscoveryInterest.java
@@ -9,6 +9,8 @@ package io.vlingo.directory.client;
 
 public interface ServiceDiscoveryInterest {
   boolean interestedIn(final String serviceName);
+
   void informDiscovered(final ServiceRegistrationInfo discoveredService);
+
   void informUnregistered(final String unregisteredServiceName);
 }

--- a/src/main/java/io/vlingo/directory/client/ServiceRegistrationInfo.java
+++ b/src/main/java/io/vlingo/directory/client/ServiceRegistrationInfo.java
@@ -18,20 +18,20 @@ import io.vlingo.wire.node.Host;
 public final class ServiceRegistrationInfo {
   public final String name;
   public final Collection<Location> locations;
-  
+
   public ServiceRegistrationInfo(final String name, final Collection<Location> locations) {
     this.name = name;
     this.locations = locations;
   }
-  
+
   @Override
   public boolean equals(final Object other) {
     if (other == null || other.getClass() != ServiceRegistrationInfo.class) {
       return false;
     }
-    
+
     final ServiceRegistrationInfo otherInfo = (ServiceRegistrationInfo) other;
-    
+
     return this.name.equals(otherInfo.name) && this.locations.equals(otherInfo.locations);
   }
 
@@ -44,7 +44,7 @@ public final class ServiceRegistrationInfo {
     static Location from(final Address address) {
       return new Location(address.hostName(), address.port());
     }
-    
+
     static Collection<Location> from(final Collection<Address> addresses) {
       final List<Location> locations = new ArrayList<>(addresses.size());
       for (final Address address : addresses) {
@@ -52,7 +52,7 @@ public final class ServiceRegistrationInfo {
       }
       return locations;
     }
-    
+
     static Collection<Address> toAddresses(final Collection<Location> locations) {
       final List<Address> addresses = new ArrayList<>(locations.size());
       for (final Location location : locations) {
@@ -63,7 +63,7 @@ public final class ServiceRegistrationInfo {
 
     public final String address;
     public final int port;
-    
+
     public Location(final String address, final int port) {
       this.address = address;
       this.port = port;
@@ -74,9 +74,9 @@ public final class ServiceRegistrationInfo {
       if (other == null || other.getClass() != Location.class) {
         return false;
       }
-      
+
       final Location otherLocation = (Location) other;
-      
+
       return this.address.equals(otherLocation.address) && this.port == otherLocation.port;
     }
 

--- a/src/main/java/io/vlingo/directory/model/DirectoryApplication.java
+++ b/src/main/java/io/vlingo/directory/model/DirectoryApplication.java
@@ -16,36 +16,36 @@ public class DirectoryApplication extends ClusterApplicationAdapter {
   private final DirectoryService directoryService;
   private boolean leading;
   private final Node localNode;
-  
+
   public DirectoryApplication(final Node localNode) {
     this.localNode = localNode;
 
     this.directoryService = DirectoryService.instance(stage(), localNode);
   }
 
-  //====================================
+  // ====================================
   // ClusterApplication
-  //====================================
+  // ====================================
 
   @Override
   public void informAttributesClient(final AttributesProtocol client) {
-     logger().log("DIRECTORY: Attributes Client received.");
-     
-     directoryService.use(client);
+    logger().log("DIRECTORY: Attributes Client received.");
+
+    directoryService.use(client);
   }
 
   @Override
   public void informLeaderElected(final Id leaderId, final boolean isHealthyCluster, final boolean isLocalNodeLeading) {
-     logger().log("DIRECTORY: Leader elected: " + leaderId);
-     
+    logger().log("DIRECTORY: Leader elected: " + leaderId);
+
     if (isLocalNodeLeading) {
       leading = true;
-       logger().log("DIRECTORY: Assigned leadership; starting processing.");
-       directoryService.assignLeadership();
+      logger().log("DIRECTORY: Assigned leadership; starting processing.");
+      directoryService.assignLeadership();
     } else {
       leading = false;
       logger().log("DIRECTORY: Remote node assigned leadership: " + leaderId);
-      
+
       // prevent split brain in case another leader pushes in. if this node
       // is not currently leading this operation will have no harm.
       directoryService.relinquishLeadership();
@@ -54,19 +54,19 @@ public class DirectoryApplication extends ClusterApplicationAdapter {
 
   @Override
   public void informLeaderLost(final Id lostLeaderId, final boolean isHealthyCluster) {
-     logger().log("DIRECTORY: Leader lost: " + lostLeaderId);
-     
-     if (localNode.id().equals(lostLeaderId)) {
-       leading = false;
-       directoryService.relinquishLeadership();
-     }
+    logger().log("DIRECTORY: Leader lost: " + lostLeaderId);
+
+    if (localNode.id().equals(lostLeaderId)) {
+      leading = false;
+      directoryService.relinquishLeadership();
+    }
   }
 
   @Override
   public void informLocalNodeShutDown(final Id nodeId) {
     logger().log("DIRECTORY: Local node left cluster: " + nodeId + "; relinquishing leadership");
     leading = false;
-    
+
     // prevent split brain in case another leader pushes in. if this node
     // is not currently leading this operation will have no harm.
     directoryService.relinquishLeadership();
@@ -77,12 +77,13 @@ public class DirectoryApplication extends ClusterApplicationAdapter {
     if (localNode.id().equals(nodeId)) {
       logger().log("DIRECTORY: Node left cluster: " + nodeId + "; relinquishing leadership");
       leading = false;
-      
+
       // prevent split brain in case another leader pushes in. if this node
       // is not currently leading this operation will have no harm.
       directoryService.relinquishLeadership();
     } else {
-      logger().log("DIRECTORY: Node left cluster: " + nodeId + (isHealthyCluster ? "; cluster still healthy" : "; cluster not healthy"));
+      logger().log("DIRECTORY: Node left cluster: " + nodeId
+              + (isHealthyCluster ? "; cluster still healthy" : "; cluster not healthy"));
     }
   }
 
@@ -99,7 +100,7 @@ public class DirectoryApplication extends ClusterApplicationAdapter {
   @Override
   public void informQuorumLost() {
     logger().log("DIRECTORY: Quorum lost; pausing processing.");
-    
+
     if (leading) {
       directoryService.relinquishLeadership();
     }
@@ -108,7 +109,7 @@ public class DirectoryApplication extends ClusterApplicationAdapter {
   @Override
   public void stop() {
     directoryService.stop();
-    
+
     super.stop();
   }
 }

--- a/src/main/java/io/vlingo/directory/model/DirectoryService.java
+++ b/src/main/java/io/vlingo/directory/model/DirectoryService.java
@@ -17,61 +17,45 @@ import io.vlingo.wire.node.Node;
 
 public interface DirectoryService extends Startable, Stoppable {
 
-  public static DirectoryService instance(
-          final Stage stage,
-          final Node localNode) {
+  public static DirectoryService instance(final Stage stage, final Node localNode) {
 
-    final Network network =
-            new Network(
-                    new Group(Properties.instance.directoryGroupAddress(), Properties.instance.directoryGroupPort()),
-                    Properties.instance.directoryIncomingPort());
+    final Network network = new Network(
+            new Group(Properties.instance.directoryGroupAddress(), Properties.instance.directoryGroupPort()),
+            Properties.instance.directoryIncomingPort());
 
     final int maxMessageSize = Properties.instance.directoryMessageBufferSize();
 
-    final Timing timing =
-            new Timing(
-                    Properties.instance.directoryMessageProcessingInterval(),
-                    Properties.instance.directoryMessagePublishingInterval());
+    final Timing timing = new Timing(Properties.instance.directoryMessageProcessingInterval(),
+            Properties.instance.directoryMessagePublishingInterval());
 
     final int unpublishedNotifications = Properties.instance.directoryUnregisteredServiceNotifications();
 
-    final DirectoryService directoryService =
-            DirectoryService.instance(
-                    stage,
-                    localNode,
-                    network,
-                    maxMessageSize,
-                    timing,
-                    unpublishedNotifications);
+    final DirectoryService directoryService = DirectoryService.instance(stage, localNode, network, maxMessageSize,
+            timing, unpublishedNotifications);
 
     return directoryService;
   }
 
-  public static DirectoryService instance(
-          final Stage stage,
-          final Node localNode,
-          final Network network,
-          final int maxMessageSize,
-          final Timing timing,
-          final int unpublishedNotifications) {
-    
-    final Definition definition =
-            Definition.has(
-                    DirectoryServiceActor.class,
-                    Definition.parameters(localNode, network, maxMessageSize, timing, unpublishedNotifications),
-                    "vlingo-directory-service");
-    
+  public static DirectoryService instance(final Stage stage, final Node localNode, final Network network,
+          final int maxMessageSize, final Timing timing, final int unpublishedNotifications) {
+
+    final Definition definition = Definition.has(DirectoryServiceActor.class,
+            Definition.parameters(localNode, network, maxMessageSize, timing, unpublishedNotifications),
+            "vlingo-directory-service");
+
     return stage.actorFor(DirectoryService.class, definition);
   }
 
   public void assignLeadership();
+
   public void relinquishLeadership();
+
   public void use(final AttributesProtocol client);
-  
+
   public static class Network {
     public final Group publisherGroup;
     public final int incomingPort;
-    
+
     public Network(final Group publisherGroup, final int incomingPort) {
       this.publisherGroup = publisherGroup;
       this.incomingPort = incomingPort;
@@ -81,7 +65,7 @@ public interface DirectoryService extends Startable, Stoppable {
   public static class Timing {
     public final int processingInterval;
     public final int publishingInterval;
-    
+
     public Timing(final int processingInterval, final int publishingInterval) {
       this.processingInterval = processingInterval;
       this.publishingInterval = publishingInterval;

--- a/src/main/java/io/vlingo/directory/model/DirectoryService__Proxy.java
+++ b/src/main/java/io/vlingo/directory/model/DirectoryService__Proxy.java
@@ -32,8 +32,11 @@ public class DirectoryService__Proxy implements DirectoryService {
   public void conclude() {
     if (!actor.isStopped()) {
       final Consumer<Stoppable> consumer = (actor) -> actor.conclude();
-      if (mailbox.isPreallocated()) { mailbox.send(actor, Stoppable.class, consumer, null, representationConclude0); }
-      else { mailbox.send(new LocalMessage<Stoppable>(actor, Stoppable.class, consumer, representationConclude0)); }
+      if (mailbox.isPreallocated()) {
+        mailbox.send(actor, Stoppable.class, consumer, null, representationConclude0);
+      } else {
+        mailbox.send(new LocalMessage<Stoppable>(actor, Stoppable.class, consumer, representationConclude0));
+      }
     } else {
       actor.deadLetters().failedDelivery(new DeadLetter(actor, representationConclude0));
     }
@@ -78,7 +81,8 @@ public class DirectoryService__Proxy implements DirectoryService {
   public void relinquishLeadership() {
     if (!actor.isStopped()) {
       final Consumer<DirectoryService> consumer = (actor) -> actor.relinquishLeadership();
-      mailbox.send(new LocalMessage<DirectoryService>(actor, DirectoryService.class, consumer, "relinquishLeadership()"));
+      mailbox.send(
+              new LocalMessage<DirectoryService>(actor, DirectoryService.class, consumer, "relinquishLeadership()"));
     } else {
       actor.deadLetters().failedDelivery(new DeadLetter(actor, "relinquishLeadership()"));
     }
@@ -88,7 +92,8 @@ public class DirectoryService__Proxy implements DirectoryService {
   public void use(final AttributesProtocol client) {
     if (!actor.isStopped()) {
       final Consumer<DirectoryService> consumer = (actor) -> actor.use(client);
-      mailbox.send(new LocalMessage<DirectoryService>(actor, DirectoryService.class, consumer, "use(AttributesProtocol)"));
+      mailbox.send(
+              new LocalMessage<DirectoryService>(actor, DirectoryService.class, consumer, "use(AttributesProtocol)"));
     } else {
       actor.deadLetters().failedDelivery(new DeadLetter(actor, "use(AttributesProtocol)"));
     }

--- a/src/main/java/io/vlingo/directory/model/Properties.java
+++ b/src/main/java/io/vlingo/directory/model/Properties.java
@@ -35,22 +35,25 @@ public final class Properties {
   protected static Properties openForTest(java.util.Properties properties) {
     return new Properties(properties);
   }
-  
+
   public String directoryGroupAddress() {
     final String address = getString("directory.group.address", "");
-    if (address.isEmpty()) throw new IllegalStateException("Must define a directory group address in properties file.");
+    if (address.isEmpty())
+      throw new IllegalStateException("Must define a directory group address in properties file.");
     return address;
   }
-  
+
   public int directoryGroupPort() {
     final int port = getInteger("directory.group.port", -1);
-    if (port == -1) throw new IllegalStateException("Must define a directory group port in properties file.");
+    if (port == -1)
+      throw new IllegalStateException("Must define a directory group port in properties file.");
     return port;
   }
 
   public int directoryIncomingPort() {
     final int port = getInteger("directory.incoming.port", -1);
-    if (port == -1) throw new IllegalStateException("Must define a directory incoming port in properties file.");
+    if (port == -1)
+      throw new IllegalStateException("Must define a directory incoming port in properties file.");
     return port;
   }
 
@@ -92,9 +95,9 @@ public final class Properties {
     // assertions in each accessor
 
     directoryGroupAddress();
-    
+
     directoryGroupPort();
-    
+
     directoryIncomingPort();
   }
 

--- a/src/main/java/io/vlingo/directory/model/message/RegisterService.java
+++ b/src/main/java/io/vlingo/directory/model/message/RegisterService.java
@@ -19,10 +19,10 @@ import io.vlingo.wire.node.Name;
 
 public class RegisterService implements Message {
   public static final String TypeName = "REGSRVC";
-  
+
   public final Set<Address> addresses;
   public final Name name;
-  
+
   public static RegisterService from(final String content) {
     if (content.startsWith(TypeName)) {
       final Name name = MessagePartsBuilder.nameFrom(content);
@@ -32,43 +32,43 @@ public class RegisterService implements Message {
     }
     return new RegisterService(Name.NO_NODE_NAME);
   }
-  
+
   public static RegisterService as(final Name name, final Address address) {
     return new RegisterService(name, address);
   }
-  
+
   public static RegisterService as(final Name name, final Collection<Address> addresses) {
     return new RegisterService(name, addresses);
   }
-  
+
   public RegisterService(final Name name, final Address address) {
     this(name);
     this.addresses.add(address);
   }
-  
+
   public RegisterService(final Name name, final Collection<Address> addresses) {
     this(name);
     this.addresses.addAll(addresses);
   }
-  
+
   public boolean isValid() {
     return !name.hasNoName();
   }
-  
+
   @Override
   public String toString() {
     final StringBuilder builder = new StringBuilder();
     final AddressType type = AddressType.MAIN;
 
     builder.append(TypeName).append("\n").append("nm=").append(name.value());
-    
+
     for (final Address address : addresses) {
       builder.append("\n").append(type.field()).append(address.host().name()).append(":").append(address.port());
     }
-    
+
     return builder.toString();
   }
-  
+
   private RegisterService(final Name name) {
     this.name = name;
     this.addresses = new HashSet<>();

--- a/src/main/java/io/vlingo/directory/model/message/ServiceRegistered.java
+++ b/src/main/java/io/vlingo/directory/model/message/ServiceRegistered.java
@@ -19,10 +19,10 @@ import io.vlingo.wire.node.Name;
 
 public class ServiceRegistered implements Message {
   public static final String TypeName = "SRVCREGD";
-  
+
   public final Set<Address> addresses;
   public final Name name;
-  
+
   public static ServiceRegistered from(final String content) {
     if (content.startsWith(TypeName)) {
       final Name name = MessagePartsBuilder.nameFrom(content);
@@ -32,20 +32,20 @@ public class ServiceRegistered implements Message {
     }
     return new ServiceRegistered(Name.NO_NODE_NAME);
   }
-  
+
   public static ServiceRegistered as(final Name name, final Address address) {
     return new ServiceRegistered(name, address);
   }
-  
+
   public static ServiceRegistered as(final Name name, final Collection<Address> addresses) {
     return new ServiceRegistered(name, addresses);
   }
-  
+
   public ServiceRegistered(final Name name, final Address address) {
     this(name);
     this.addresses.add(address);
   }
-  
+
   public ServiceRegistered(final Name name, final Collection<Address> addresses) {
     this(name);
     this.addresses.addAll(addresses);
@@ -61,14 +61,14 @@ public class ServiceRegistered implements Message {
     final AddressType type = AddressType.MAIN;
 
     builder.append(TypeName).append("\n").append("nm=").append(name.value());
-    
+
     for (final Address address : addresses) {
       builder.append("\n").append(type.field()).append(address.host().name()).append(":").append(address.port());
     }
-    
+
     return builder.toString();
   }
-  
+
   private ServiceRegistered(final Name name) {
     this.name = name;
     this.addresses = new HashSet<>();

--- a/src/main/java/io/vlingo/directory/model/message/ServiceUnregistered.java
+++ b/src/main/java/io/vlingo/directory/model/message/ServiceUnregistered.java
@@ -13,9 +13,9 @@ import io.vlingo.wire.node.Name;
 
 public class ServiceUnregistered implements Message {
   public static final String TypeName = "SRVCUNREGD";
-  
+
   public final Name name;
-  
+
   public static ServiceUnregistered from(final String content) {
     if (content.startsWith(TypeName)) {
       final Name name = MessagePartsBuilder.nameFrom(content);
@@ -23,11 +23,11 @@ public class ServiceUnregistered implements Message {
     }
     return new ServiceUnregistered(Name.NO_NODE_NAME);
   }
-  
+
   public static ServiceUnregistered as(final Name name) {
     return new ServiceUnregistered(name);
   }
-  
+
   public ServiceUnregistered(final Name name) {
     this.name = name;
   }
@@ -41,7 +41,7 @@ public class ServiceUnregistered implements Message {
     final StringBuilder builder = new StringBuilder();
 
     builder.append(TypeName).append("\n").append("nm=").append(name.value());
-    
+
     return builder.toString();
   }
 }

--- a/src/main/java/io/vlingo/directory/model/message/UnregisterService.java
+++ b/src/main/java/io/vlingo/directory/model/message/UnregisterService.java
@@ -13,9 +13,9 @@ import io.vlingo.wire.node.Name;
 
 public class UnregisterService implements Message {
   public static final String TypeName = "UNREGSRVC";
-  
+
   public final Name name;
-  
+
   public static UnregisterService from(final String content) {
     if (content.startsWith(TypeName)) {
       final Name name = MessagePartsBuilder.nameFrom(content);
@@ -23,25 +23,25 @@ public class UnregisterService implements Message {
     }
     return new UnregisterService(Name.NO_NODE_NAME);
   }
-  
+
   public static UnregisterService as(final Name name) {
     return new UnregisterService(name);
   }
-  
+
   public UnregisterService(final Name name) {
     this.name = name;
   }
-  
+
   public boolean isValid() {
     return !name.hasNoName();
   }
-  
+
   @Override
   public String toString() {
     final StringBuilder builder = new StringBuilder();
 
     builder.append(TypeName).append("\n").append("nm=").append(name.value());
-    
+
     return builder.toString();
   }
 }

--- a/src/test/java/io/vlingo/directory/client/MockServiceDiscoveryInterest.java
+++ b/src/test/java/io/vlingo/directory/client/MockServiceDiscoveryInterest.java
@@ -44,24 +44,24 @@ public class MockServiceDiscoveryInterest implements ServiceDiscoveryInterest {
 
   @Override
   public boolean interestedIn(final String serviceName) {
-      if (!this.servicesSeen.contains(serviceName)) {
-          this.result.writeUsing("servicesSeen", serviceName);
-      }
-      return true;
+    if (!this.servicesSeen.contains(serviceName)) {
+      this.result.writeUsing("servicesSeen", serviceName);
+    }
+    return true;
   }
 
   @Override
   public void informDiscovered(final ServiceRegistrationInfo discoveredService) {
-      if (!this.discoveredServices.contains(discoveredService)) {
-          this.result.writeUsing("discoveredServices", discoveredService);
-      }
+    if (!this.discoveredServices.contains(discoveredService)) {
+      this.result.writeUsing("discoveredServices", discoveredService);
+    }
   }
 
   @Override
   public void informUnregistered(final String unregisteredServiceName) {
-      if (!this.unregisteredServices.contains(unregisteredServiceName)) {
-          this.result.writeUsing("unregisteredServices", unregisteredServiceName);
-      }
+    if (!this.unregisteredServices.contains(unregisteredServiceName)) {
+      this.result.writeUsing("unregisteredServices", unregisteredServiceName);
+    }
   }
 
   public List<ServiceRegistrationInfo> getDiscoveredServices() {

--- a/src/test/java/io/vlingo/directory/client/ServiceRegistrationInfoTest.java
+++ b/src/test/java/io/vlingo/directory/client/ServiceRegistrationInfoTest.java
@@ -17,36 +17,33 @@ public class ServiceRegistrationInfoTest {
 
   @Test
   public void testInfo() {
-    final ServiceRegistrationInfo info =
-            new ServiceRegistrationInfo(
-                    "test-service",
-                    Arrays.asList(new Location("1.2.3.4", 111), new Location("1.2.3.45", 222)));
-    
+    final ServiceRegistrationInfo info = new ServiceRegistrationInfo("test-service",
+            Arrays.asList(new Location("1.2.3.4", 111), new Location("1.2.3.45", 222)));
+
     assertEquals("test-service", info.name);
     assertEquals(2, info.locations.size());
     final Iterator<Location> iter = info.locations.iterator();
     assertEquals(new Location("1.2.3.4", 111), iter.next());
     assertEquals(new Location("1.2.3.45", 222), iter.next());
-    
-    final ServiceRegistrationInfo infoAgain =
-            new ServiceRegistrationInfo(
-                    "test-service",
-                    Arrays.asList(new Location("1.2.3.4", 111), new Location("1.2.3.45", 222)));
-    
+
+    final ServiceRegistrationInfo infoAgain = new ServiceRegistrationInfo("test-service",
+            Arrays.asList(new Location("1.2.3.4", 111), new Location("1.2.3.45", 222)));
+
     assertEquals(info, infoAgain);
   }
-  
+
   @Test
   public void testToFrom() {
-    final Collection<Location> twoLocations = Arrays.asList(new Location("1.2.3.4", 111), new Location("1.2.3.45", 222));
+    final Collection<Location> twoLocations = Arrays.asList(new Location("1.2.3.4", 111),
+            new Location("1.2.3.45", 222));
     final Collection<Address> twoAddresses = Location.toAddresses(twoLocations);
-    
+
     final Iterator<Address> iter = twoAddresses.iterator();
     assertEquals(new Address(Host.of("1.2.3.4"), 111, AddressType.MAIN), iter.next());
     assertEquals(new Address(Host.of("1.2.3.45"), 222, AddressType.MAIN), iter.next());
-    
+
     assertEquals(twoLocations.iterator().next(), Location.from(twoAddresses.iterator().next()));
-    
+
     final Collection<Location> convertedLocations = Location.from(twoAddresses);
     assertEquals(twoLocations, convertedLocations);
   }

--- a/src/test/java/io/vlingo/directory/model/TestAttributesClient.java
+++ b/src/test/java/io/vlingo/directory/model/TestAttributesClient.java
@@ -13,11 +13,11 @@ import io.vlingo.cluster.model.attribute.TrackedAttribute;
 
 public class TestAttributesClient implements AttributesProtocol {
   private final Map<String, AttributeSet> attributeSets;
-  
+
   public TestAttributesClient() {
     attributeSets = new HashMap<>();
   }
-  
+
   @Override
   public <T> void add(final String attributeSetName, final String attributeName, final T value) {
     AttributeSet set = attributeSets.get(attributeSetName);
@@ -63,13 +63,13 @@ public class TestAttributesClient implements AttributesProtocol {
   @Override
   public <T> void replace(String attributeSetName, String attributeName, T value) {
     final AttributeSet set = attributeSets.get(attributeSetName);
-    
+
     if (!set.isNone()) {
       final TrackedAttribute tracked = set.attributeNamed(attributeName);
-      
+
       if (tracked.isPresent()) {
         final Attribute<T> other = Attribute.from(attributeName, value);
-        
+
         if (!tracked.sameAs(other)) {
           set.replace(tracked.replacingValueWith(other));
         }
@@ -80,14 +80,14 @@ public class TestAttributesClient implements AttributesProtocol {
   @Override
   public <T> void remove(String attributeSetName, String attributeName) {
     final AttributeSet set = attributeSets.get(attributeSetName);
-    
+
     if (!set.isNone()) {
       final TrackedAttribute tracked = set.attributeNamed(attributeName);
-      
+
       if (tracked.isPresent()) {
         set.remove(tracked.attribute);
       }
-    }    
+    }
   }
 
   @Override

--- a/src/test/java/io/vlingo/directory/model/message/RegisterServiceTest.java
+++ b/src/test/java/io/vlingo/directory/model/message/RegisterServiceTest.java
@@ -23,22 +23,18 @@ public class RegisterServiceTest {
 
   @Test
   public void testMessage() {
-    final RegisterService registerService =
-            new RegisterService(
-                    Name.of("test-service"),
-                    Address.from(Host.of("1.2.3.4"), 111, AddressType.MAIN));
-    
+    final RegisterService registerService = new RegisterService(Name.of("test-service"),
+            Address.from(Host.of("1.2.3.4"), 111, AddressType.MAIN));
+
     assertEquals(1, registerService.addresses.size());
     assertEquals(textMessage, registerService.toString());
   }
-  
+
   @Test
   public void testValidity() {
-    final RegisterService registerService =
-            new RegisterService(
-                    Name.of("test-service"),
-                    Address.from(Host.of("1.2.3.4"), 111, AddressType.MAIN));
-    
+    final RegisterService registerService = new RegisterService(Name.of("test-service"),
+            Address.from(Host.of("1.2.3.4"), 111, AddressType.MAIN));
+
     assertTrue(registerService.isValid());
     assertFalse(RegisterService.from("blah").isValid());
     assertTrue(RegisterService.from(textMessage).isValid());

--- a/src/test/java/io/vlingo/directory/model/message/ServiceRegisteredTest.java
+++ b/src/test/java/io/vlingo/directory/model/message/ServiceRegisteredTest.java
@@ -25,26 +25,20 @@ public class ServiceRegisteredTest {
 
   @Test
   public void testMessage() {
-    final ServiceRegistered serviceRegistered =
-            new ServiceRegistered(
-                    Name.of("test-service"),
-                    Arrays.asList(
-                            Address.from(Host.of("1.2.3.4"), 111, AddressType.MAIN),
-                            Address.from(Host.of("1.2.3.45"), 222, AddressType.MAIN)));
-    
+    final ServiceRegistered serviceRegistered = new ServiceRegistered(Name.of("test-service"),
+            Arrays.asList(Address.from(Host.of("1.2.3.4"), 111, AddressType.MAIN),
+                    Address.from(Host.of("1.2.3.45"), 222, AddressType.MAIN)));
+
     assertEquals(2, serviceRegistered.addresses.size());
     assertEquals(textMessage, serviceRegistered.toString());
   }
-  
+
   @Test
   public void testValidity() {
-    final ServiceRegistered serviceRegistered =
-            new ServiceRegistered(
-                    Name.of("test-service"),
-                    Arrays.asList(
-                            Address.from(Host.of("1.2.3.4"), 111, AddressType.MAIN),
-                            Address.from(Host.of("1.2.3.45"), 222, AddressType.MAIN)));
-    
+    final ServiceRegistered serviceRegistered = new ServiceRegistered(Name.of("test-service"),
+            Arrays.asList(Address.from(Host.of("1.2.3.4"), 111, AddressType.MAIN),
+                    Address.from(Host.of("1.2.3.45"), 222, AddressType.MAIN)));
+
     assertTrue(serviceRegistered.isValid());
     assertFalse(ServiceRegistered.from("blah").isValid());
     assertTrue(ServiceRegistered.from(textMessage).isValid());

--- a/src/test/java/io/vlingo/directory/model/message/UnregisterServiceTest.java
+++ b/src/test/java/io/vlingo/directory/model/message/UnregisterServiceTest.java
@@ -21,7 +21,7 @@ public class UnregisterServiceTest {
   @Test
   public void testMessage() {
     final UnregisterService unregisterService = UnregisterService.as(Name.of("test-service"));
-    
+
     assertEquals(Name.of("test-service"), unregisterService.name);
     assertEquals(textMessage, unregisterService.toString());
   }
@@ -29,7 +29,7 @@ public class UnregisterServiceTest {
   @Test
   public void testValidity() {
     final UnregisterService unregisterService = UnregisterService.as(Name.of("test-service"));
-    
+
     assertTrue(unregisterService.isValid());
     assertFalse(UnregisterService.from("blah").isValid());
     assertTrue(UnregisterService.from(textMessage).isValid());


### PR DESCRIPTION
Configured https://github.com/diffplug/spotless plugin in order to enforce common formatting rules, defined in the `resources/eclipse-java-formatter.xml`.
Also commited the reformated source code. 

Note that some files had their style changed quite heavily, for example `DirectoryClient.java`. Most certanly the formatting rules could be improved. 

The plugin runs automatically on every build. 